### PR TITLE
Доработка для корректной работы с ПГ.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "stable",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "yiisoft/yii" : "~1.1.15",
         "intersvyaz/pdo-oci8": ">=1.0.0"
     },


### PR DESCRIPTION
Первая доработка оказалась не рабочей, т.к. в родительском классе немного отличается логика по регенерации сессий и получению данных для записи в сессию. Поэтому тут сделана доработка, чтобы текущая логика работала для остальных типов баз.